### PR TITLE
Enable live stream of selected camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Custom component for lovelace to be used as a panel for viewing security cameras
 | show_capture_buttons | boolean | Show screenshot and record buttons | true
 | recording_duration | number | Number of seconds to record after clicking record button (_min_ 0.5) | 10
 | focus_motion | boolean | Switch to camera when motion detected | true
+| camera_view | string | “live” will show the live view if  the `stream` integration is enabled. | ""
 
 ### Camera configuration
 

--- a/surveillance-card.js
+++ b/surveillance-card.js
@@ -38,10 +38,28 @@ class SurveillanceCard extends LitElement {
             })}
         </div>
         <div class="mainImage">
-          <img src="${this.selectedCamera.stream_url}" alt="${this.selectedCamera.name}" />
+          ${this.renderMain()}
         </div>
       </div>
     `;
+  }
+
+  renderMain() {
+    if (this.liveStream) {
+      const cameraObj = this.hass.states[this.selectedCamera.entity];
+      if (!cameraObj) {
+        return html``;
+      }
+      
+      return html`
+        <ha-camera-stream
+          .hass=${this.hass}
+          .stateObj="${cameraObj}"
+        ></ha-camera-stream>
+      `;
+    }
+    
+    return html`<img src="${this.selectedCamera.stream_url}" alt="${this.selectedCamera.name}" />`;
   }
 
   static get properties() {
@@ -53,7 +71,8 @@ class SurveillanceCard extends LitElement {
       thumbInterval: { type: Number },
       updateInterval: { type: Number },
       recordingDuration: { type: Number },
-      showCaptureButtons: { type: Boolean }
+      showCaptureButtons: { type: Boolean },
+      liveStream: { type: Boolean }
     };
   }
 
@@ -86,6 +105,7 @@ class SurveillanceCard extends LitElement {
     this.updateInterval = config.update_interval || 1.0;
     this.recordingDuration = config.recording_duration || 10.0;
     this.showCaptureButtons = config.show_capture_buttons !== false;
+    this.liveStream = config.camera_view === "live";
 
     // There must be better way to tell if HA front end running from app or browser
     // Confirmed working on iOS, should be verified on Android app


### PR DESCRIPTION
If you have the HA `stream` integration enabled, then cameras that support it can live stream to Lovelace cards. In the `picture-elements`, `picture-glance` and `picture-entity` cards, you can simply specify `camera_view: "live"` in the configuration to enable this.

This change adds the `camera_view` option to the surveillance card. The `ha-camera-stream` component handles all the harder parts, so this change mainly hooks up the option and renders the `ha-camera-stream` component instead of the `img` for the selected camera if streaming is enabled.

I have Nest cameras and it seems to work pretty well with them.

This is my first time messing around with lovelace cards and I have limited LitElement experience so let me know if there is anything you want tweaked.

I also updated the README.