### PR TITLE
Support changing thumbnail position

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Custom component for lovelace to be used as a panel for viewing security cameras
 | recording_duration | number | Number of seconds to record after clicking record button (_min_ 0.5) | 10
 | focus_motion | boolean | Switch to camera when motion detected | true
 | camera_view | string | “live” will show the live view if  the `stream` integration is enabled. | ""
+| thumb_position | string | Position of the thumbnails (left, right, top, botton, none) | left
 
 ### Camera configuration
 

--- a/surveillance-card.js
+++ b/surveillance-card.js
@@ -20,7 +20,7 @@ class SurveillanceCard extends LitElement {
     const showToolbarClass = ( !this.isMobileApp && this.showCaptureButtons ) ? "" : "hidden";
 
     return html`
-      <div class="container">
+    <div class="container thumbs-${this.thumbPosition}">
         <div class="thumbs">
           ${this.cameras.filter((c) => c.access_token).map((camera) => {
               let thumbClass = camera.has_motion ? "thumb motion" : "thumb";
@@ -68,6 +68,7 @@ class SurveillanceCard extends LitElement {
       selectedCamera: { type: Object },
       focusOnMotion: { type: Boolean },
       thumbInterval: { type: Number },
+      thumbPosition: { type: String },
       updateInterval: { type: Number },
       recordingDuration: { type: Number },
       showCaptureButtons: { type: Boolean },
@@ -105,6 +106,7 @@ class SurveillanceCard extends LitElement {
     this.recordingDuration = config.recording_duration || 10.0;
     this.showCaptureButtons = config.show_capture_buttons !== false;
     this.liveStream = config.camera_view === "live";
+    this.thumbPosition = config.thumb_position || "left";
 
     // There must be better way to tell if HA front end running from app or browser
     // Confirmed working on iOS, should be verified on Android app
@@ -233,6 +235,33 @@ class SurveillanceCard extends LitElement {
         overflow-y: auto;
         position: relative;
         text-align:center;
+      }
+
+      .container.thumbs-left {
+
+      }
+      .container.thumbs-right {
+        flex-direction: row-reverse;
+      }
+
+      .container.thumbs-top {
+        flex-direction: column;
+      }
+      .container.thumbs-top .thumbs {
+        display: flex;
+        flex: unset;
+      }
+
+      .container.thumbs-bottom {
+        flex-direction: column-reverse;
+      }
+      .container.thumbs-bottom .thumbs {
+        display: flex;
+        flex: unset;
+      }
+
+      .container.thumbs-none .thumbs {
+        display: none;
       }
 
       .thumb > img {


### PR DESCRIPTION
Fixes #48 
Fixes #31 
Fixes #39

Allows setting the position of the thumbnails - `left`, `right`, `top` or `bottom` - or hide them altogether with `none` 