### PR TITLE
Allow muting of cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Surveillance Card is a custom component for lovelace to be used as a panel for v
 | focus_motion | boolean | Switch to camera when motion detected | true
 | camera_view | string | “live” will show the live view if  the `stream` integration is enabled. | ""
 | thumb_position | string | Position of the thumbnails (left, right, top, bottom, none) | left
+| muted | boolean | Enable to mute the audio from the cameras | false
 
 ### Camera Parameters
 

--- a/surveillance-card.js
+++ b/surveillance-card.js
@@ -54,6 +54,7 @@ class SurveillanceCard extends LitElement {
         <ha-camera-stream
           .hass=${this.hass}
           .stateObj="${cameraObj}"
+          ${this.muted ? "muted" : ""}
         ></ha-camera-stream>
       `;
     }
@@ -69,6 +70,7 @@ class SurveillanceCard extends LitElement {
       focusOnMotion: { type: Boolean },
       thumbInterval: { type: Number },
       thumbPosition: { type: String },
+      muted: { type: Boolean },
       updateInterval: { type: Number },
       recordingDuration: { type: Number },
       showCaptureButtons: { type: Boolean },
@@ -107,6 +109,7 @@ class SurveillanceCard extends LitElement {
     this.showCaptureButtons = config.show_capture_buttons !== false;
     this.liveStream = config.camera_view === "live";
     this.thumbPosition = config.thumb_position || "left";
+    this.muted = config.muted === true;
 
     // There must be better way to tell if HA front end running from app or browser
     // Confirmed working on iOS, should be verified on Android app


### PR DESCRIPTION
Fixes https://github.com/custom-cards/surveillance-card/issues/61

Allows setting `muted` boolean to mute the camera streams on the dashboard.